### PR TITLE
Add support to pass extra arguments to flatc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,8 +178,8 @@ impl Flatc {
     }
 
     /// New `flatc` command from specified path
-    pub fn from_path(path: PathBuf) -> Flatc {
-        Flatc { exec: path }
+    pub fn from_path(path: &Path) -> Flatc {
+        Flatc { exec: path.into() }
     }
 
     /// Check `flatc` command found and valid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ impl Flatc {
     }
 
     /// New `flatc` command from specified path
-    pub fn from_path(path: &Path) -> Flatc {
+    pub fn from_path<P: std::convert::Into<PathBuf>>(path: P) -> Flatc {
         Flatc { exec: path.into() }
     }
 
@@ -275,10 +275,8 @@ impl Flatc {
             cmd_args.push("--json".into());
         }
 
-        if !args.extra.is_empty() {
-            for extra_arg in args.extra {
-                cmd_args.push(extra_arg.into());
-            }
+        for extra_arg in args.extra {
+            cmd_args.push(extra_arg.into());
         }
 
         if args.lang.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,8 @@ pub struct Args<'a> {
     pub schema: bool,
     /// Set the flatc '--json' flag
     pub json: bool,
+    /// Extra args to pass to flatc
+    pub extra: &'a [&'a str],
 }
 
 impl Default for Args<'_> {
@@ -153,6 +155,7 @@ impl Default for Args<'_> {
             binary: false,
             schema: false,
             json: false,
+            extra: &[],
         }
     }
 }
@@ -270,6 +273,12 @@ impl Flatc {
 
         if args.json {
             cmd_args.push("--json".into());
+        }
+
+        if !args.extra.is_empty() {
+            for extra_arg in args.extra {
+                cmd_args.push(extra_arg.into());
+            }
         }
 
         if args.lang.is_empty() {


### PR DESCRIPTION
Added the ability to pass a list of arbitrary arguments to flatc so that we can use arguments other than the ones supported by the current `Args` struct. While it might be good to extend the `Args` struct to include more of the supported flatc args, I think it's still important to support any argument the user wants.

Solves issues #9

Update Flatc::from_path to take &Path instead of PathBuf. Taking a PathBuf forces `from_path` to take ownership of the passed in`PathBuf` which forces the user to clone it if they want to use it again. Taking a `&Path` doesn't take ownership but still clones it internally.