### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/frol/flatc-rust/compare/v0.2.0...v0.2.1) - 2024-02-10
+
+### Other
+- Updated references to the flatc package in various distributions
+- Fixed badges in the README
+- Fixed CI
+- Added release-plz to automate release management
+- Add dependabot ([#12](https://github.com/frol/flatc-rust/pull/12))
+- updated flatbuffers package in the example and resolved compatibility issues
+- (cargo-release) start next development iteration 0.2.1-alpha.0
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flatc-rust"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Vlad Frolov <frolvlad@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `flatc-rust`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/frol/flatc-rust/compare/v0.2.0...v0.2.1) - 2024-02-10

### Other
- Updated references to the flatc package in various distributions
- Fixed badges in the README
- Fixed CI
- Added release-plz to automate release management
- Add dependabot ([#12](https://github.com/frol/flatc-rust/pull/12))
- updated flatbuffers package in the example and resolved compatibility issues
- (cargo-release) start next development iteration 0.2.1-alpha.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).