### PR TITLE
mod: bumped tutorial flatbuffers dep 22.9.29->25.2.10

### DIFF
--- a/examples/tutorial/Cargo.toml
+++ b/examples/tutorial/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 flatc-rust = { path = "../../" }
 
 [dependencies]
-flatbuffers = "22.9.29"
+flatbuffers = "25.2.10"


### PR DESCRIPTION
On Fedora 41 running `flatc version 24.3.25` the tutorial failed to compile. Bumping the flatbuffers dependency solved this issue.